### PR TITLE
fix member constructors ordering

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -120,10 +120,10 @@ namespace diff_drive_controller{
   public:
     DiffDriveController()
       : command_struct_(),
-        wheel_radius_(0.0),
         wheel_separation_(0.0),
-        wheel_radius_multiplier_(1.0),
-        wheel_separation_multiplier_(1.0)
+        wheel_radius_(0.0),
+        wheel_separation_multiplier_(1.0),
+        wheel_radius_multiplier_(1.0)
     {
     }
 


### PR DESCRIPTION
Just reorder the member constructors, so we don't have warnings/errors with cppcheck
