### PR TITLE
Fix diff drive unit test

### DIFF
--- a/diff_drive_controller/test/diff_drive_controller.test
+++ b/diff_drive_controller/test/diff_drive_controller.test
@@ -32,5 +32,8 @@
   <test test-name="diff_drive_test"
         pkg="diff_drive_controller"
         type="diff_drive_test"
-        time-limit="80.0"/>
+        time-limit="80.0">
+    <remap from="cmd_vel" to="diffbot_controller/cmd_vel" />
+    <remap from="odom" to="diffbot_controller/odom" />
+  </test>
 </launch>

--- a/diff_drive_controller/test/diffbot_controllers.yaml
+++ b/diff_drive_controller/test/diffbot_controllers.yaml
@@ -5,3 +5,4 @@ diffbot_controller:
    publish_rate: 50.0 # defaults to 50
    pose_covariance_diagonal: [0.001, 0.001, 1000000.0, 1000000.0, 1000000.0, 1000.0]
    twist_covariance_diagonal: [0.001, 0.001, 1000000.0, 1000000.0, 1000000.0, 1000.0]
+   cmd_vel_old_threshold: 20.0 # a proper test for this will be made later


### PR DESCRIPTION
Previous commits left the diff drive unit tests broken. This is a fix for them.
Proper unit tests will be done for pending pull requests.
