### PR TITLE
diff_drive: add missing dependency to controller_interface

### DIFF
--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(diff_drive_controller)
 
-find_package(catkin REQUIRED COMPONENTS urdf angles)
+find_package(catkin REQUIRED COMPONENTS controller_interface urdf angles)
 
 catkin_package(
   INCLUDE_DIRS include


### PR DESCRIPTION
Without this it doesn't build with clang. We should be careful about missing symbols in shared libraries.
