### PR TITLE
diff_drive: fix nasty crash on some platforms (at least on OSX)

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -99,7 +99,7 @@ static bool getWheelRadius(const boost::shared_ptr<const urdf::Link>& wheel_link
     return false;
   }
 
-  wheel_radius = (dynamic_cast<urdf::Cylinder*>(wheel_link->collision->geometry.get()))->radius;
+  wheel_radius = (static_cast<urdf::Cylinder*>(wheel_link->collision->geometry.get()))->radius;
   return true;
 }
 


### PR DESCRIPTION
This one is nasty. Because we _manually_ load the controller at runtime,
we have to build it with special flags to export the run-time type
information (rtti) needed for stuff like dynamic_cast. But we don't, and
here it's simpler to just use a static_cast.

See here: http://gcc.gnu.org/faq.html#dso

A dynamic_cast without a check is stupid anyway. (_what could possibly
go wrong?..._)
