### PR TITLE
diff_drive: use backslashes in doxygen documentation

### DIFF
--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -58,31 +58,31 @@ namespace diff_drive_controller{
     DiffDriveController();
 
     /**
-     * @brief Initialize controller
-     * @param hw            Velocity joint interface for the wheels
-     * @param root_nh       Node handle at root namespace
-     * @param controller_nh Node handle inside the controller namespace
+     * \brief Initialize controller
+     * \param hw            Velocity joint interface for the wheels
+     * \param root_nh       Node handle at root namespace
+     * \param controller_nh Node handle inside the controller namespace
      */
     bool init(hardware_interface::VelocityJointInterface* hw,
               ros::NodeHandle& root_nh,
               ros::NodeHandle &controller_nh);
 
     /**
-     * @brief Updates controller, i.e. computes the odometry and sets the new velocity commands
-     * @param time   Current time
-     * @param period Time since the last called to update
+     * \brief Updates controller, i.e. computes the odometry and sets the new velocity commands
+     * \param time   Current time
+     * \param period Time since the last called to update
      */
     void update(const ros::Time& time, const ros::Duration& period);
 
     /**
-     * @brief Starts controller
-     * @param time Current time
+     * \brief Starts controller
+     * \param time Current time
      */
     void starting(const ros::Time& time);
 
     /**
-     * @brief Stops controller
-     * @param time Current time
+     * \brief Stops controller
+     * \param time Current time
      */
     void stopping(const ros::Time& time);
 
@@ -136,30 +136,30 @@ namespace diff_drive_controller{
 
   private:
     /**
-     * @brief Brakes the wheels, i.e. sets the velocity to 0
+     * \brief Brakes the wheels, i.e. sets the velocity to 0
      */
     void brake();
 
     /**
-     * @brief Velocity command callback
-     * @param command Velocity command message (twist)
+     * \brief Velocity command callback
+     * \param command Velocity command message (twist)
      */
     void cmdVelCallback(const geometry_msgs::Twist& command);
 
     /**
-     * @brief Sets odometry parameters from the URDF, i.e. the wheel radius and separation
-     * @param root_nh Root node handle
-     * @param left_wheel_name Name of the left wheel joint
-     * @param right_wheel_name Name of the right wheel joint
+     * \brief Sets odometry parameters from the URDF, i.e. the wheel radius and separation
+     * \param root_nh Root node handle
+     * \param left_wheel_name Name of the left wheel joint
+     * \param right_wheel_name Name of the right wheel joint
      */
     bool setOdomParamsFromUrdf(ros::NodeHandle& root_nh,
                                const std::string& left_wheel_name,
                                const std::string& right_wheel_name);
 
     /**
-     * @brief Sets the odometry publishing fields
-     * @param root_nh Root node handle
-     * @param controller_nh Node handle inside the controller namespace
+     * \brief Sets the odometry publishing fields
+     * \param root_nh Root node handle
+     * \param controller_nh Node handle inside the controller namespace
      */
     void setOdomPubFields(ros::NodeHandle& root_nh, ros::NodeHandle& controller_nh);
 

--- a/diff_drive_controller/include/diff_drive_controller/odometry.h
+++ b/diff_drive_controller/include/diff_drive_controller/odometry.h
@@ -51,7 +51,7 @@ namespace diff_drive_controller
   namespace bacc = boost::accumulators;
 
   /**
-   * @brief The Odometry class handles odometry readings
+   * \brief The Odometry class handles odometry readings
    * (2D pose and velocity with related timestamp)
    */
   class Odometry
@@ -62,25 +62,25 @@ namespace diff_drive_controller
     typedef boost::function<void(double, double)> IntegrationFunction;
 
     /**
-     * @brief Constructor
+     * \brief Constructor
      * Timestamp will get the current time value
      * Value will be set to zero
-     * @param velocity_rolling_window_size Rolling window size used to compute the velocity mean
+     * \param velocity_rolling_window_size Rolling window size used to compute the velocity mean
      */
     Odometry(size_t velocity_rolling_window_size = 10);
 
     /**
-     * @brief Updates the odometry class with latest wheels position
-     * @param left_pos  Left  wheel position [rad]
-     * @param right_pos Right wheel position [rad]
-     * @param time      Current time
-     * @return true if the odometry is actually updated
+     * \brief Updates the odometry class with latest wheels position
+     * \param left_pos  Left  wheel position [rad]
+     * \param right_pos Right wheel position [rad]
+     * \param time      Current time
+     * \return true if the odometry is actually updated
      */
     bool update(double left_pos, double right_pos, const ros::Time &time);
-    
+
     /**
-     * @brief heading getter
-     * @return heading [rad]
+     * \brief heading getter
+     * \return heading [rad]
      */
     double getHeading() const
     {
@@ -88,8 +88,8 @@ namespace diff_drive_controller
     }
 
     /**
-     * @brief x position getter
-     * @return x position [m]
+     * \brief x position getter
+     * \return x position [m]
      */
     double getX() const
     {
@@ -97,8 +97,8 @@ namespace diff_drive_controller
     }
 
     /**
-     * @brief y position getter
-     * @return y positioin [m]
+     * \brief y position getter
+     * \return y positioin [m]
      */
     double getY() const
     {
@@ -106,8 +106,8 @@ namespace diff_drive_controller
     }
 
     /**
-     * @brief timestamp getter
-     * @return timestamp
+     * \brief timestamp getter
+     * \return timestamp
      */
     ros::Time getTimestamp() const
     {
@@ -115,21 +115,21 @@ namespace diff_drive_controller
     }
 
     /**
-     * @brief Retrieves the linear velocity estimation
-     * @return Rolling mean estimation of the linear velocity [m]
+     * \brief Retrieves the linear velocity estimation
+     * \return Rolling mean estimation of the linear velocity [m]
      */
     double getLinearEstimated() const;
 
     /**
-     * @brief Retrieves the angular velocity estimation
-     * @return Rolling mean estimation of the angular velocity [rad/s]
+     * \brief Retrieves the angular velocity estimation
+     * \return Rolling mean estimation of the angular velocity [rad/s]
      */
     double getAngularEstimated() const;
 
     /**
-     * @brief Sets the wheel parameters: radius and separation
-     * @param wheel_separation Seperation between left and right wheels [m]
-     * @param wheel_radius     Wheel radius [m]
+     * \brief Sets the wheel parameters: radius and separation
+     * \param wheel_separation Seperation between left and right wheels [m]
+     * \param wheel_radius     Wheel radius [m]
      */
     void setWheelParams(double wheel_separation, double wheel_radius);
 
@@ -140,16 +140,16 @@ namespace diff_drive_controller
     typedef bacc::tag::rolling_window RollingWindow;
 
     /**
-     * @brief Integrates the velocities (linear and angular) using 2nd order Runge-Kutta
-     * @param linear  Linear  velocity   [m] (linear  displacement, i.e. m/s * dt) computed by encoders
-     * @param angular Angular velocity [rad] (angular displacement, i.e. m/s * dt) computed by encoders
+     * \brief Integrates the velocities (linear and angular) using 2nd order Runge-Kutta
+     * \param linear  Linear  velocity   [m] (linear  displacement, i.e. m/s * dt) computed by encoders
+     * \param angular Angular velocity [rad] (angular displacement, i.e. m/s * dt) computed by encoders
      */
     void integrationByRungeKutta(double linear, double angular);
 
     /**
-     * @brief Integrates the velocities (linear and angular) using exact method
-     * @param linear  Linear  velocity   [m] (linear  displacement, i.e. m/s * dt) computed by encoders
-     * @param angular Angular velocity [rad] (angular displacement, i.e. m/s * dt) computed by encoders
+     * \brief Integrates the velocities (linear and angular) using exact method
+     * \param linear  Linear  velocity   [m] (linear  displacement, i.e. m/s * dt) computed by encoders
+     * \param angular Angular velocity [rad] (angular displacement, i.e. m/s * dt) computed by encoders
      */
     void integrationExact(double linear, double angular);
 

--- a/diff_drive_controller/include/diff_drive_controller/speed_limiter.h
+++ b/diff_drive_controller/include/diff_drive_controller/speed_limiter.h
@@ -47,13 +47,13 @@ namespace diff_drive_controller
   public:
 
     /**
-     * @brief Constructor
-     * @param [in] has_velocity_limits     if true, applies velocity limits
-     * @param [in] has_acceleration_limits if true, applies acceleration limits
-     * @param [in] min_velocity Minimum velocity [m/s], usually <= 0
-     * @param [in] max_velocity Maximum velocity [m/s], usually >= 0
-     * @param [in] min_acceleration Minimum acceleration [m/s^2], usually <= 0
-     * @param [in] max_acceleration Maximum acceleration [m/s^2], usually >= 0
+     * \brief Constructor
+     * \param [in] has_velocity_limits     if true, applies velocity limits
+     * \param [in] has_acceleration_limits if true, applies acceleration limits
+     * \param [in] min_velocity Minimum velocity [m/s], usually <= 0
+     * \param [in] max_velocity Maximum velocity [m/s], usually >= 0
+     * \param [in] min_acceleration Minimum acceleration [m/s^2], usually <= 0
+     * \param [in] max_acceleration Maximum acceleration [m/s^2], usually >= 0
      */
     SpeedLimiter(
       bool has_velocity_limits = false,
@@ -65,24 +65,24 @@ namespace diff_drive_controller
     );
 
     /**
-     * @brief Limit the velocity and acceleration
-     * @param [in, out] v  Velocity [m/s]
-     * @param [in]      v0 Previous velocity [m/s]
-     * @param [in]      dt Time step [s]
+     * \brief Limit the velocity and acceleration
+     * \param [in, out] v  Velocity [m/s]
+     * \param [in]      v0 Previous velocity [m/s]
+     * \param [in]      dt Time step [s]
      */
     void limit(double& v, double v0, double dt);
 
     /**
-     * @brief Limit the velocity
-     * @param [in, out] v Velocity [m/s]
+     * \brief Limit the velocity
+     * \param [in, out] v Velocity [m/s]
      */
     void limit_velocity(double& v);
 
     /**
-     * @brief Limit the acceleration
-     * @param [in, out] v  Velocity [m/s]
-     * @param [in]      v0 Previous velocity [m/s]
-     * @param [in]      dt Time step [s]
+     * \brief Limit the acceleration
+     * \param [in, out] v  Velocity [m/s]
+     * \param [in]      v0 Previous velocity [m/s]
+     * \param [in]      dt Time step [s]
      */
     void limit_acceleration(double& v, double v0, double dt);
 

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -52,9 +52,9 @@ static double euclideanOfVectors(const urdf::Vector3& vec1, const urdf::Vector3&
 }
 
 /*
- * @brief Check if the link is modeled as a cylinder
- * @param link Link
- * @return true if the link is modeled as a Cylinder; false otherwise
+ * \brief Check if the link is modeled as a cylinder
+ * \param link Link
+ * \return true if the link is modeled as a Cylinder; false otherwise
  */
 static bool isCylinder(const boost::shared_ptr<const urdf::Link>& link)
 {
@@ -86,10 +86,10 @@ static bool isCylinder(const boost::shared_ptr<const urdf::Link>& link)
 }
 
 /*
- * @brief Get the wheel radius
- * @param [in]  wheel_link   Wheel link
- * @param [out] wheel_radius Wheel radius [m]
- * @return true if the wheel radius was found; false otherwise
+ * \brief Get the wheel radius
+ * \param [in]  wheel_link   Wheel link
+ * \param [out] wheel_radius Wheel radius [m]
+ * \return true if the wheel radius was found; false otherwise
  */
 static bool getWheelRadius(const boost::shared_ptr<const urdf::Link>& wheel_link, double& wheel_radius)
 {

--- a/diff_drive_controller/src/odometry.cpp
+++ b/diff_drive_controller/src/odometry.cpp
@@ -125,9 +125,9 @@ namespace diff_drive_controller
   }
 
   /**
-   * @brief Other possible integration method provided by the class
-   * @param linear
-   * @param angular
+   * \brief Other possible integration method provided by the class
+   * \param linear
+   * \param angular
    */
   void Odometry::integrationExact(double linear, double angular)
   {


### PR DESCRIPTION
Minor fix for issue #30
