### PR TITLE
checks for NaN left/right position to ignore them

### DIFF
--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -40,6 +40,10 @@ if (CATKIN_ENABLE_TESTING)
 
   add_rostest_gtest(diff_drive_test test/diff_drive_controller.test test/diff_drive_test.cpp)
   target_link_libraries(diff_drive_test ${catkin_LIBRARIES})
+  add_rostest_gtest(diff_drive_nan_test
+    test/diff_drive_controller_nan.test
+    test/diff_drive_nan_test.cpp)
+  target_link_libraries(diff_drive_nan_test ${catkin_LIBRARIES})
   add_rostest_gtest(diff_drive_limits_test
     test/diff_drive_controller_limits.test
     test/diff_drive_limits_test.cpp)

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -193,8 +193,13 @@ namespace diff_drive_controller{
   void DiffDriveController::update(const ros::Time& time, const ros::Duration& period)
   {
     // COMPUTE AND PUBLISH ODOMETRY
+    const double left_pos  = left_wheel_joint_.getPosition();
+    const double right_pos = right_wheel_joint_.getPosition();
+    if (std::isnan(left_pos) || std::isnan(right_pos))
+      return;
+
     // Estimate linear and angular velocity using joint information
-    odometry_.update(left_wheel_joint_.getPosition(), right_wheel_joint_.getPosition(), time);
+    odometry_.update(left_pos, right_pos, time);
 
     // Publish odometry message
     if (last_state_publish_time_ + publish_period_ < time)

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -197,8 +197,13 @@ namespace diff_drive_controller{
   void DiffDriveController::update(const ros::Time& time, const ros::Duration& period)
   {
     // COMPUTE AND PUBLISH ODOMETRY
+    const double& left_pos  = left_wheel_joint_.getPosition();
+    const double& right_pos = right_wheel_joint_.getPosition();
+    if (std::isnan(left_pos) || std::isnan(right_pos))
+      return;
+
     // Estimate linear and angular velocity using joint information
-    odometry_.update(left_wheel_joint_.getPosition(), right_wheel_joint_.getPosition(), time);
+    odometry_.update(left_pos, right_pos, time);
 
     // Publish odometry message
     if (last_state_publish_time_ + publish_period_ < time)

--- a/diff_drive_controller/test/diff_drive_controller_nan.test
+++ b/diff_drive_controller/test/diff_drive_controller_nan.test
@@ -1,0 +1,13 @@
+<launch>
+  <!-- Load common test stuff -->
+  <include file="$(find diff_drive_controller)/test/diff_drive_common.launch" />
+
+  <!-- Controller test -->
+  <test test-name="diff_drive_nan_test"
+        pkg="diff_drive_controller"
+        type="diff_drive_nan_test"
+        time-limit="80.0">
+    <remap from="cmd_vel" to="diffbot_controller/cmd_vel" />
+    <remap from="odom" to="diffbot_controller/odom" />
+  </test>
+</launch>

--- a/diff_drive_controller/test/diff_drive_fail_test.cpp
+++ b/diff_drive_controller/test/diff_drive_fail_test.cpp
@@ -39,7 +39,7 @@ TEST_F(DiffDriveControllerTest, testWrongJointName)
     ros::Duration(1.0).sleep();
     secs++;
   }
-  // give up and assume controller load failure after 5 secondds
+  // give up and assume controller load failure after 5 seconds
   EXPECT_GE(secs, 5);
 }
 

--- a/diff_drive_controller/test/diff_drive_nan_test.cpp
+++ b/diff_drive_controller/test/diff_drive_nan_test.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////////
-// Copyright (C) 2013, PAL Robotics S.L.
+// Copyright (C) 2014, PAL Robotics S.L.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:

--- a/diff_drive_controller/test/diff_drive_nan_test.cpp
+++ b/diff_drive_controller/test/diff_drive_nan_test.cpp
@@ -1,0 +1,100 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2013, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics, Inc. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+/// \author Enrique Fernandez
+
+#include "test_common.h"
+
+// NaN
+#include <limits>
+
+// TEST CASES
+TEST_F(DiffDriveControllerTest, testNaN)
+{
+  // wait for ROS
+  while(!isControllerAlive())
+  {
+    ros::Duration(0.1).sleep();
+  }
+  // zero everything before test
+  geometry_msgs::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  ros::Duration(2.0).sleep();
+
+  // send a command
+  cmd_vel.linear.x = 0.1;
+  ros::Duration(2.0).sleep();
+
+  // stop robot (will generate NaN)
+  stop();
+  ros::Duration(2.0).sleep();
+
+  nav_msgs::Odometry odom = getLastOdom();
+
+  EXPECT_NE(odom.twist.twist.linear.x, std::numeric_limits<double>::quiet_NaN());
+  EXPECT_NE(odom.twist.twist.angular.z, std::numeric_limits<double>::quiet_NaN());
+  EXPECT_NE(odom.pose.pose.position.x, std::numeric_limits<double>::quiet_NaN());
+  EXPECT_NE(odom.pose.pose.position.y, std::numeric_limits<double>::quiet_NaN());
+  EXPECT_NE(odom.pose.pose.position.z, std::numeric_limits<double>::quiet_NaN());
+  EXPECT_NE(odom.pose.pose.orientation.x, std::numeric_limits<double>::quiet_NaN());
+  EXPECT_NE(odom.pose.pose.orientation.x, std::numeric_limits<double>::quiet_NaN());
+  EXPECT_NE(odom.pose.pose.orientation.y, std::numeric_limits<double>::quiet_NaN());
+  EXPECT_NE(odom.pose.pose.orientation.z, std::numeric_limits<double>::quiet_NaN());
+  EXPECT_NE(odom.pose.pose.orientation.w, std::numeric_limits<double>::quiet_NaN());
+
+  // start robot
+  start();
+  ros::Duration(2.0).sleep();
+
+  odom = getLastOdom();
+
+  EXPECT_NE(odom.twist.twist.linear.x, std::numeric_limits<double>::quiet_NaN());
+  EXPECT_NE(odom.twist.twist.angular.z, std::numeric_limits<double>::quiet_NaN());
+  EXPECT_NE(odom.pose.pose.position.x, std::numeric_limits<double>::quiet_NaN());
+  EXPECT_NE(odom.pose.pose.position.y, std::numeric_limits<double>::quiet_NaN());
+  EXPECT_NE(odom.pose.pose.position.z, std::numeric_limits<double>::quiet_NaN());
+  EXPECT_NE(odom.pose.pose.orientation.x, std::numeric_limits<double>::quiet_NaN());
+  EXPECT_NE(odom.pose.pose.orientation.x, std::numeric_limits<double>::quiet_NaN());
+  EXPECT_NE(odom.pose.pose.orientation.y, std::numeric_limits<double>::quiet_NaN());
+  EXPECT_NE(odom.pose.pose.orientation.z, std::numeric_limits<double>::quiet_NaN());
+  EXPECT_NE(odom.pose.pose.orientation.w, std::numeric_limits<double>::quiet_NaN());
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "diff_drive_nan_test");
+
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+  int ret = RUN_ALL_TESTS();
+  spinner.stop();
+  ros::shutdown();
+  return ret;
+}

--- a/diff_drive_controller/test/diff_drive_nan_test.cpp
+++ b/diff_drive_controller/test/diff_drive_nan_test.cpp
@@ -57,16 +57,12 @@ TEST_F(DiffDriveControllerTest, testNaN)
 
   nav_msgs::Odometry odom = getLastOdom();
 
-  EXPECT_NE(odom.twist.twist.linear.x, std::numeric_limits<double>::quiet_NaN());
-  EXPECT_NE(odom.twist.twist.angular.z, std::numeric_limits<double>::quiet_NaN());
-  EXPECT_NE(odom.pose.pose.position.x, std::numeric_limits<double>::quiet_NaN());
-  EXPECT_NE(odom.pose.pose.position.y, std::numeric_limits<double>::quiet_NaN());
-  EXPECT_NE(odom.pose.pose.position.z, std::numeric_limits<double>::quiet_NaN());
-  EXPECT_NE(odom.pose.pose.orientation.x, std::numeric_limits<double>::quiet_NaN());
-  EXPECT_NE(odom.pose.pose.orientation.x, std::numeric_limits<double>::quiet_NaN());
-  EXPECT_NE(odom.pose.pose.orientation.y, std::numeric_limits<double>::quiet_NaN());
-  EXPECT_NE(odom.pose.pose.orientation.z, std::numeric_limits<double>::quiet_NaN());
-  EXPECT_NE(odom.pose.pose.orientation.w, std::numeric_limits<double>::quiet_NaN());
+  EXPECT_NE(std::isnan(odom.twist.twist.linear.x), true);
+  EXPECT_NE(std::isnan(odom.twist.twist.angular.z), true);
+  EXPECT_NE(std::isnan(odom.pose.pose.position.x), true);
+  EXPECT_NE(std::isnan(odom.pose.pose.position.y), true);
+  EXPECT_NE(std::isnan(odom.pose.pose.orientation.z), true);
+  EXPECT_NE(std::isnan(odom.pose.pose.orientation.w), true);
 
   // start robot
   start();
@@ -74,16 +70,12 @@ TEST_F(DiffDriveControllerTest, testNaN)
 
   odom = getLastOdom();
 
-  EXPECT_NE(odom.twist.twist.linear.x, std::numeric_limits<double>::quiet_NaN());
-  EXPECT_NE(odom.twist.twist.angular.z, std::numeric_limits<double>::quiet_NaN());
-  EXPECT_NE(odom.pose.pose.position.x, std::numeric_limits<double>::quiet_NaN());
-  EXPECT_NE(odom.pose.pose.position.y, std::numeric_limits<double>::quiet_NaN());
-  EXPECT_NE(odom.pose.pose.position.z, std::numeric_limits<double>::quiet_NaN());
-  EXPECT_NE(odom.pose.pose.orientation.x, std::numeric_limits<double>::quiet_NaN());
-  EXPECT_NE(odom.pose.pose.orientation.x, std::numeric_limits<double>::quiet_NaN());
-  EXPECT_NE(odom.pose.pose.orientation.y, std::numeric_limits<double>::quiet_NaN());
-  EXPECT_NE(odom.pose.pose.orientation.z, std::numeric_limits<double>::quiet_NaN());
-  EXPECT_NE(odom.pose.pose.orientation.w, std::numeric_limits<double>::quiet_NaN());
+  EXPECT_NE(std::isnan(odom.twist.twist.linear.x), true);
+  EXPECT_NE(std::isnan(odom.twist.twist.angular.z), true);
+  EXPECT_NE(std::isnan(odom.pose.pose.position.x), true);
+  EXPECT_NE(std::isnan(odom.pose.pose.position.y), true);
+  EXPECT_NE(std::isnan(odom.pose.pose.orientation.z), true);
+  EXPECT_NE(std::isnan(odom.pose.pose.orientation.w), true);
 }
 
 int main(int argc, char** argv)

--- a/diff_drive_controller/test/diffbot.cpp
+++ b/diff_drive_controller/test/diffbot.cpp
@@ -89,6 +89,9 @@ public:
     {
       for (unsigned int i = 0; i < 2; ++i)
       {
+        // Note that pos_[i] will be NaN for one more cycle after we start(),
+        // but that is consistent with the knowledge we have about the state
+        // of the robot.
         pos_[i] += vel_[i]*getPeriod().toSec(); // update position
         vel_[i] = cmd_[i]; // might add smoothing here later
       }

--- a/diff_drive_controller/test/test_common.h
+++ b/diff_drive_controller/test/test_common.h
@@ -37,6 +37,8 @@
 #include <nav_msgs/Odometry.h>
 #include <tf/tf.h>
 
+#include <std_srvs/Empty.h>
+
 // Floating-point value comparison threshold
 const double EPS = 0.01;
 const double POSITION_TOLERANCE = 0.01; // 1 cm-s precision
@@ -48,8 +50,10 @@ class DiffDriveControllerTest : public ::testing::Test
 public:
 
   DiffDriveControllerTest()
-    : cmd_pub(nh.advertise<geometry_msgs::Twist>("cmd_vel", 100)),
-      odom_sub(nh.subscribe("odom", 100, &DiffDriveControllerTest::odomCallback, this))
+  : cmd_pub(nh.advertise<geometry_msgs::Twist>("cmd_vel", 100))
+  , odom_sub(nh.subscribe("odom", 100, &DiffDriveControllerTest::odomCallback, this))
+  , start_srv(nh.serviceClient<std_srvs::Empty>("start"))
+  , stop_srv(nh.serviceClient<std_srvs::Empty>("stop"))
   {
   }
 
@@ -62,11 +66,17 @@ public:
   void publish(geometry_msgs::Twist cmd_vel){ cmd_pub.publish(cmd_vel); }
   bool isControllerAlive(){ return (odom_sub.getNumPublishers() > 0) && (cmd_pub.getNumSubscribers() > 0); }
 
+  void start(){ std_srvs::Empty srv; start_srv.call(srv); }
+  void stop(){ std_srvs::Empty srv; stop_srv.call(srv); }
+
 private:
   ros::NodeHandle nh;
   ros::Publisher cmd_pub;
   ros::Subscriber odom_sub;
   nav_msgs::Odometry last_odom;
+
+  ros::ServiceClient start_srv;
+  ros::ServiceClient stop_srv;
 
   void odomCallback(const nav_msgs::Odometry& odom)
   {


### PR DESCRIPTION
Just checked that it builds, but neither tested in a robot or gazebo.
Also, there's no test.

How can this be tested in gazebo?
How should we write a test for this?

To test on a robot, reboot the robot with the wheel's board disabled and check the odom topic and TF.
You shouldn't see any 'nan'.
Then, switch on the wheel's board and move the robot.
Now the odom topic and TF show change and you should see valid values, not 'nan'.
