### PR TITLE
Open-loop odometry

### DIFF
--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -38,7 +38,9 @@ if (CATKIN_ENABLE_TESTING)
 
   add_dependencies(tests diffbot)
 
-  add_rostest_gtest(diff_drive_test test/diff_drive_controller.test test/diff_drive_test.cpp)
+  add_rostest_gtest(diff_drive_test
+    test/diff_drive_controller.test
+    test/diff_drive_test.cpp)
   target_link_libraries(diff_drive_test ${catkin_LIBRARIES})
   add_rostest_gtest(diff_drive_nan_test
     test/diff_drive_controller_nan.test
@@ -58,5 +60,6 @@ if (CATKIN_ENABLE_TESTING)
     test/diff_drive_fail_test.cpp)
   target_link_libraries(diff_drive_fail_test ${catkin_LIBRARIES})
   add_rostest(test/diff_drive_bad_urdf.test)
+  add_rostest(test/diff_drive_open_loop.test)
 
 endif()

--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -98,9 +98,10 @@ namespace diff_drive_controller{
   private:
     std::string name_;
 
-    /// Publish rate related:
+    /// Odometry related:
     ros::Duration publish_period_;
     ros::Time last_state_publish_time_;
+    bool open_loop_;
 
     /// Hardware handles:
     hardware_interface::JointHandle left_wheel_joint_;

--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -124,7 +124,6 @@ namespace diff_drive_controller{
     boost::shared_ptr<realtime_tools::RealtimePublisher<nav_msgs::Odometry> > odom_pub_;
     boost::shared_ptr<realtime_tools::RealtimePublisher<tf::tfMessage> > tf_odom_pub_;
     Odometry odometry_;
-    geometry_msgs::TransformStamped odom_frame_;
 
     /// Wheel separation, wrt the midpoint of the wheel width:
     double wheel_separation_;
@@ -142,7 +141,7 @@ namespace diff_drive_controller{
     /// Frame to use for the robot base:
     std::string base_frame_id_;
 
-    // speed limiters
+    // Speed limiters:
     Commands last_cmd_;
     SpeedLimiter limiter_lin_;
     SpeedLimiter limiter_ang_;

--- a/diff_drive_controller/include/diff_drive_controller/odometry.h
+++ b/diff_drive_controller/include/diff_drive_controller/odometry.h
@@ -72,6 +72,12 @@ namespace diff_drive_controller
     Odometry(size_t velocity_rolling_window_size = 10);
 
     /**
+     * \brief Initialize the odometry
+     * \param time Current time
+     */
+    void init(const ros::Time &time);
+
+    /**
      * \brief Updates the odometry class with latest wheels position
      * \param left_pos  Left  wheel position [rad]
      * \param right_pos Right wheel position [rad]
@@ -180,7 +186,8 @@ namespace diff_drive_controller
     double left_wheel_old_pos_;
     double right_wheel_old_pos_;
 
-    /// Rolling meand accumulators for the linar and angular velocities:
+    /// Rolling mean accumulators for the linar and angular velocities:
+    size_t velocity_rolling_window_size_;
     RollingMeanAcc linear_acc_;
     RollingMeanAcc angular_acc_;
 

--- a/diff_drive_controller/include/diff_drive_controller/odometry.h
+++ b/diff_drive_controller/include/diff_drive_controller/odometry.h
@@ -35,6 +35,8 @@
 /*
  * Author: Luca Marchionni
  * Author: Bence Magyar
+ * Author: Enrique Fernández
+ * Author: Paul Mathieu
  */
 
 #ifndef ODOMETRY_H_
@@ -83,9 +85,8 @@ namespace diff_drive_controller
      * \param linear  Linear velocity [m/s]
      * \param angular Angular velocity [rad/s]
      * \param time    Current time
-     * \return true if the odometry is actually updated
      */
-    bool update_open_loop(double linear, double angular, const ros::Time &time);
+    void updateOpenLoop(double linear, double angular, const ros::Time &time);
 
     /**
      * \brief heading getter
@@ -133,27 +134,6 @@ namespace diff_drive_controller
     }
 
     /**
-     * \brief timestamp getter
-     * \return timestamp
-     */
-    ros::Time getTimestamp() const
-    {
-      return timestamp_;
-    }
-
-    /**
-     * \brief Retrieves the linear velocity estimation
-     * \return Rolling mean estimation of the linear velocity [m]
-     */
-    double getLinearEstimated() const;
-
-    /**
-     * \brief Retrieves the angular velocity estimation
-     * \return Rolling mean estimation of the angular velocity [rad/s]
-     */
-    double getAngularEstimated() const;
-
-    /**
      * \brief Sets the wheel parameters: radius and separation
      * \param wheel_separation Seperation between left and right wheels [m]
      * \param wheel_radius     Wheel radius [m]
@@ -188,7 +168,7 @@ namespace diff_drive_controller
     double y_;        //   [m]
     double heading_;  // [rad]
 
-    /// Current velocity (for open loop mode):
+    /// Current velocity:
     double linear_;  //   [m/s]
     double angular_; // [rad/s]
 

--- a/diff_drive_controller/include/diff_drive_controller/odometry.h
+++ b/diff_drive_controller/include/diff_drive_controller/odometry.h
@@ -79,6 +79,15 @@ namespace diff_drive_controller
     bool update(double left_pos, double right_pos, const ros::Time &time);
 
     /**
+     * \brief Updates the odometry class with latest velocity command
+     * \param linear  Linear velocity [m/s]
+     * \param angular Angular velocity [rad/s]
+     * \param time    Current time
+     * \return true if the odometry is actually updated
+     */
+    bool update_open_loop(double linear, double angular, const ros::Time &time);
+
+    /**
      * \brief heading getter
      * \return heading [rad]
      */
@@ -98,11 +107,29 @@ namespace diff_drive_controller
 
     /**
      * \brief y position getter
-     * \return y positioin [m]
+     * \return y position [m]
      */
     double getY() const
     {
       return y_;
+    }
+
+    /**
+     * \brief linear velocity getter
+     * \return linear velocity [m/s]
+     */
+    double getLinear() const
+    {
+      return linear_;
+    }
+
+    /**
+     * \brief angular velocity getter
+     * \return angular velocity [rad/s]
+     */
+    double getAngular() const
+    {
+      return angular_;
     }
 
     /**
@@ -160,6 +187,10 @@ namespace diff_drive_controller
     double x_;        //   [m]
     double y_;        //   [m]
     double heading_;  // [rad]
+
+    /// Current velocity (for open loop mode):
+    double linear_;  //   [m/s]
+    double angular_; // [rad/s]
 
     /// Wheel kinematic parameters [m]:
     double wheel_separation_;

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -286,6 +286,8 @@ namespace diff_drive_controller{
 
     // Register starting time used to keep fixed rate
     last_state_publish_time_ = time;
+
+    odometry_.init(time);
   }
 
   void DiffDriveController::stopping(const ros::Time& time)

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -202,16 +202,14 @@ namespace diff_drive_controller{
   void DiffDriveController::update(const ros::Time& time, const ros::Duration& period)
   {
     // COMPUTE AND PUBLISH ODOMETRY
-    double left_pos;
-    double right_pos;
     if (open_loop_)
     {
-      odometry_.update_open_loop(last_cmd_.lin, last_cmd_.ang, time);
+      odometry_.updateOpenLoop(last_cmd_.lin, last_cmd_.ang, time);
     }
     else
     {
-      left_pos  = left_wheel_joint_.getPosition();
-      right_pos = right_wheel_joint_.getPosition();
+      const double left_pos  = left_wheel_joint_.getPosition();
+      double right_pos = right_wheel_joint_.getPosition();
       if (std::isnan(left_pos) || std::isnan(right_pos))
         return;
 
@@ -234,27 +232,19 @@ namespace diff_drive_controller{
         odom_pub_->msg_.pose.pose.position.x = odometry_.getX();
         odom_pub_->msg_.pose.pose.position.y = odometry_.getY();
         odom_pub_->msg_.pose.pose.orientation = orientation;
-        if (open_loop_)
-        {
-          odom_pub_->msg_.twist.twist.linear.x  = odometry_.getLinear();
-          odom_pub_->msg_.twist.twist.angular.z = odometry_.getAngular();
-        }
-        else
-        {
-          odom_pub_->msg_.twist.twist.linear.x  = odometry_.getLinearEstimated();
-          odom_pub_->msg_.twist.twist.angular.z = odometry_.getAngularEstimated();
-        }
+        odom_pub_->msg_.twist.twist.linear.x  = odometry_.getLinear();
+        odom_pub_->msg_.twist.twist.angular.z = odometry_.getAngular();
         odom_pub_->unlockAndPublish();
       }
 
       // Publish tf /odom frame
       if (tf_odom_pub_->trylock())
       {
-        odom_frame_.header.stamp = time;
-        odom_frame_.transform.translation.x = odometry_.getX();
-        odom_frame_.transform.translation.y = odometry_.getY();
-        odom_frame_.transform.rotation = orientation;
-        tf_odom_pub_->msg_.transforms[0] = odom_frame_;
+        geometry_msgs::TransformStamped& odom_frame = tf_odom_pub_->msg_.transforms[0];
+        odom_frame.header.stamp = time;
+        odom_frame.transform.translation.x = odometry_.getX();
+        odom_frame.transform.translation.y = odometry_.getY();
+        odom_frame.transform.rotation = orientation;
         tf_odom_pub_->unlockAndPublish();
       }
     }
@@ -272,7 +262,7 @@ namespace diff_drive_controller{
     }
 
     // Limit velocities and accelerations:
-    double cmd_dt = period.toSec();
+    const double cmd_dt(period.toSec());
     limiter_lin_.limit(curr_cmd.lin, last_cmd_.lin, cmd_dt);
     limiter_ang_.limit(curr_cmd.ang, last_cmd_.ang, cmd_dt);
     last_cmd_ = curr_cmd;
@@ -412,28 +402,28 @@ namespace diff_drive_controller{
     odom_pub_->msg_.child_frame_id = base_frame_id_;
     odom_pub_->msg_.pose.pose.position.z = 0;
     odom_pub_->msg_.pose.covariance = boost::assign::list_of
-        (static_cast<double>(pose_cov_list[0])) (0)   (0)  (0)  (0)  (0)
-        (0) (static_cast<double>(pose_cov_list[1]))  (0)  (0)  (0)  (0)
-        (0)   (0)  (static_cast<double>(pose_cov_list[2])) (0)  (0)  (0)
-        (0)   (0)   (0) (static_cast<double>(pose_cov_list[3])) (0)  (0)
-        (0)   (0)   (0)  (0) (static_cast<double>(pose_cov_list[4])) (0)
-        (0)   (0)   (0)  (0)  (0)  (static_cast<double>(pose_cov_list[5]));
+        (static_cast<double>(pose_cov_list[0])) (0)  (0)  (0)  (0)  (0)
+        (0)  (static_cast<double>(pose_cov_list[1])) (0)  (0)  (0)  (0)
+        (0)  (0)  (static_cast<double>(pose_cov_list[2])) (0)  (0)  (0)
+        (0)  (0)  (0)  (static_cast<double>(pose_cov_list[3])) (0)  (0)
+        (0)  (0)  (0)  (0)  (static_cast<double>(pose_cov_list[4])) (0)
+        (0)  (0)  (0)  (0)  (0)  (static_cast<double>(pose_cov_list[5]));
     odom_pub_->msg_.twist.twist.linear.y  = 0;
     odom_pub_->msg_.twist.twist.linear.z  = 0;
     odom_pub_->msg_.twist.twist.angular.x = 0;
     odom_pub_->msg_.twist.twist.angular.y = 0;
     odom_pub_->msg_.twist.covariance = boost::assign::list_of
-        (static_cast<double>(twist_cov_list[0])) (0)   (0)  (0)  (0)  (0)
-        (0) (static_cast<double>(twist_cov_list[1]))  (0)  (0)  (0)  (0)
-        (0)   (0)  (static_cast<double>(twist_cov_list[2])) (0)  (0)  (0)
-        (0)   (0)   (0) (static_cast<double>(twist_cov_list[3])) (0)  (0)
-        (0)   (0)   (0)  (0) (static_cast<double>(twist_cov_list[4])) (0)
-        (0)   (0)   (0)  (0)  (0)  (static_cast<double>(twist_cov_list[5]));
+        (static_cast<double>(twist_cov_list[0])) (0)  (0)  (0)  (0)  (0)
+        (0)  (static_cast<double>(twist_cov_list[1])) (0)  (0)  (0)  (0)
+        (0)  (0)  (static_cast<double>(twist_cov_list[2])) (0)  (0)  (0)
+        (0)  (0)  (0)  (static_cast<double>(twist_cov_list[3])) (0)  (0)
+        (0)  (0)  (0)  (0)  (static_cast<double>(twist_cov_list[4])) (0)
+        (0)  (0)  (0)  (0)  (0)  (static_cast<double>(twist_cov_list[5]));
     tf_odom_pub_.reset(new realtime_tools::RealtimePublisher<tf::tfMessage>(root_nh, "/tf", 100));
     tf_odom_pub_->msg_.transforms.resize(1);
-    odom_frame_.transform.translation.z = 0.0;
-    odom_frame_.child_frame_id = base_frame_id_;
-    odom_frame_.header.frame_id = "odom";
+    tf_odom_pub_->msg_.transforms[0].transform.translation.z = 0.0;
+    tf_odom_pub_->msg_.transforms[0].child_frame_id = base_frame_id_;
+    tf_odom_pub_->msg_.transforms[0].header.frame_id = "odom";
   }
 
 } // namespace diff_drive_controller

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -108,7 +108,8 @@ static bool getWheelRadius(const boost::shared_ptr<const urdf::Link>& wheel_link
 namespace diff_drive_controller{
 
   DiffDriveController::DiffDriveController()
-    : command_struct_()
+    : open_loop_(false)
+    , command_struct_()
     , wheel_separation_(0.0)
     , wheel_radius_(0.0)
     , wheel_separation_multiplier_(1.0)
@@ -141,11 +142,14 @@ namespace diff_drive_controller{
       return false;
     }
 
+    // Odometry related:
     double publish_rate;
     controller_nh.param("publish_rate", publish_rate, 50.0);
     ROS_INFO_STREAM_NAMED(name_, "Controller state will be published at "
                           << publish_rate << "Hz.");
     publish_period_ = ros::Duration(1.0 / publish_rate);
+
+    controller_nh.param("open_loop", open_loop_, open_loop_);
 
     controller_nh.param("wheel_separation_multiplier", wheel_separation_multiplier_, wheel_separation_multiplier_);
     ROS_INFO_STREAM_NAMED(name_, "Wheel separation will be multiplied by "
@@ -155,6 +159,7 @@ namespace diff_drive_controller{
     ROS_INFO_STREAM_NAMED(name_, "Wheel radius will be multiplied by "
                           << wheel_radius_multiplier_ << ".");
 
+    // Twist command related:
     controller_nh.param("cmd_vel_timeout", cmd_vel_timeout_, cmd_vel_timeout_);
     ROS_INFO_STREAM_NAMED(name_, "Velocity commands will be considered old if they are older than "
                           << cmd_vel_timeout_ << "s.");
@@ -197,13 +202,22 @@ namespace diff_drive_controller{
   void DiffDriveController::update(const ros::Time& time, const ros::Duration& period)
   {
     // COMPUTE AND PUBLISH ODOMETRY
-    const double left_pos  = left_wheel_joint_.getPosition();
-    const double right_pos = right_wheel_joint_.getPosition();
-    if (std::isnan(left_pos) || std::isnan(right_pos))
-      return;
+    double left_pos;
+    double right_pos;
+    if (open_loop_)
+    {
+      odometry_.update_open_loop(last_cmd_.lin, last_cmd_.ang, time);
+    }
+    else
+    {
+      left_pos  = left_wheel_joint_.getPosition();
+      right_pos = right_wheel_joint_.getPosition();
+      if (std::isnan(left_pos) || std::isnan(right_pos))
+        return;
 
-    // Estimate linear and angular velocity using joint information
-    odometry_.update(left_pos, right_pos, time);
+      // Estimate linear and angular velocity using joint information
+      odometry_.update(left_pos, right_pos, time);
+    }
 
     // Publish odometry message
     if (last_state_publish_time_ + publish_period_ < time)
@@ -220,8 +234,16 @@ namespace diff_drive_controller{
         odom_pub_->msg_.pose.pose.position.x = odometry_.getX();
         odom_pub_->msg_.pose.pose.position.y = odometry_.getY();
         odom_pub_->msg_.pose.pose.orientation = orientation;
-        odom_pub_->msg_.twist.twist.linear.x  = odometry_.getLinearEstimated();
-        odom_pub_->msg_.twist.twist.angular.z = odometry_.getAngularEstimated();
+        if (open_loop_)
+        {
+          odom_pub_->msg_.twist.twist.linear.x  = odometry_.getLinear();
+          odom_pub_->msg_.twist.twist.angular.z = odometry_.getAngular();
+        }
+        else
+        {
+          odom_pub_->msg_.twist.twist.linear.x  = odometry_.getLinearEstimated();
+          odom_pub_->msg_.twist.twist.angular.z = odometry_.getAngularEstimated();
+        }
         odom_pub_->unlockAndPublish();
       }
 

--- a/diff_drive_controller/src/odometry.cpp
+++ b/diff_drive_controller/src/odometry.cpp
@@ -60,7 +60,7 @@ namespace diff_drive_controller
   {
   }
 
-  bool Odometry::update(double left_pos, double right_pos, const ros::Time &time)
+  bool Odometry::update(double left_pos, double right_pos, const ros::Time& time)
   {
     /// Get current wheel joint positions:
     const double left_wheel_cur_pos  = left_pos  * wheel_radius_;
@@ -91,6 +91,21 @@ namespace diff_drive_controller
     /// Estimate speeds using a rolling mean to filter them out:
     linear_acc_(linear/dt);
     angular_acc_(angular/dt);
+
+    return true;
+  }
+
+  bool Odometry::update_open_loop(double linear, double angular, const ros::Time& time)
+  {
+    /// Save last linear and angular velocity:
+    linear_ = linear;
+    angular_ = angular;
+
+    const double dt = (time - timestamp_).toSec();
+    timestamp_ = time;
+
+    /// Integrate odometry:
+    integrate_fun_(linear * dt, angular * dt);
 
     return true;
   }

--- a/diff_drive_controller/src/odometry.cpp
+++ b/diff_drive_controller/src/odometry.cpp
@@ -33,7 +33,10 @@
  *********************************************************************/
 
 /*
+ * Author: Luca Marchionni
+ * Author: Bence Magyar
  * Author: Enrique Fernández
+ * Author: Paul Mathieu
  */
 
 #include <diff_drive_controller/odometry.h>
@@ -46,21 +49,23 @@ namespace diff_drive_controller
   namespace bacc = boost::accumulators;
 
   Odometry::Odometry(size_t velocity_rolling_window_size)
-  : timestamp_(0.0),
-    x_(0.0),
-    y_(0.0),
-    heading_(0.0),
-    wheel_separation_(0.0),
-    wheel_radius_(0.0),
-    left_wheel_old_pos_(0.0),
-    right_wheel_old_pos_(0.0),
-    linear_acc_(RollingWindow::window_size = velocity_rolling_window_size),
-    angular_acc_(RollingWindow::window_size = velocity_rolling_window_size),
-    integrate_fun_(boost::bind(&Odometry::integrateExact, this, _1, _2))
+  : timestamp_(0.0)
+  , x_(0.0)
+  , y_(0.0)
+  , heading_(0.0)
+  , linear_(0.0)
+  , angular_(0.0)
+  , wheel_separation_(0.0)
+  , wheel_radius_(0.0)
+  , left_wheel_old_pos_(0.0)
+  , right_wheel_old_pos_(0.0)
+  , linear_acc_(RollingWindow::window_size = velocity_rolling_window_size)
+  , angular_acc_(RollingWindow::window_size = velocity_rolling_window_size)
+  , integrate_fun_(boost::bind(&Odometry::integrateExact, this, _1, _2))
   {
   }
 
-  bool Odometry::update(double left_pos, double right_pos, const ros::Time& time)
+  bool Odometry::update(double left_pos, double right_pos, const ros::Time &time)
   {
     /// Get current wheel joint positions:
     const double left_wheel_cur_pos  = left_pos  * wheel_radius_;
@@ -92,32 +97,22 @@ namespace diff_drive_controller
     linear_acc_(linear/dt);
     angular_acc_(angular/dt);
 
+    linear_ = bacc::rolling_mean(linear_acc_);
+    angular_ = bacc::rolling_mean(angular_acc_);
+
     return true;
   }
 
-  bool Odometry::update_open_loop(double linear, double angular, const ros::Time& time)
+  void Odometry::updateOpenLoop(double linear, double angular, const ros::Time &time)
   {
     /// Save last linear and angular velocity:
     linear_ = linear;
     angular_ = angular;
 
+    /// Integrate odometry:
     const double dt = (time - timestamp_).toSec();
     timestamp_ = time;
-
-    /// Integrate odometry:
     integrate_fun_(linear * dt, angular * dt);
-
-    return true;
-  }
-
-  double Odometry::getLinearEstimated() const
-  {
-    return bacc::rolling_mean(linear_acc_);
-  }
-
-  double Odometry::getAngularEstimated() const
-  {
-    return bacc::rolling_mean(angular_acc_);
   }
 
   void Odometry::setWheelParams(double wheel_separation, double wheel_radius)

--- a/diff_drive_controller/src/odometry.cpp
+++ b/diff_drive_controller/src/odometry.cpp
@@ -59,10 +59,21 @@ namespace diff_drive_controller
   , wheel_radius_(0.0)
   , left_wheel_old_pos_(0.0)
   , right_wheel_old_pos_(0.0)
+  , velocity_rolling_window_size_(velocity_rolling_window_size)
   , linear_acc_(RollingWindow::window_size = velocity_rolling_window_size)
   , angular_acc_(RollingWindow::window_size = velocity_rolling_window_size)
   , integrate_fun_(boost::bind(&Odometry::integrateExact, this, _1, _2))
   {
+  }
+
+  void Odometry::init(const ros::Time& time)
+  {
+    // Reset accumulators:
+    linear_acc_ = RollingMeanAcc(RollingWindow::window_size = velocity_rolling_window_size_);
+    angular_acc_ = RollingMeanAcc(RollingWindow::window_size = velocity_rolling_window_size_);
+
+    // Reset timestamp:
+    timestamp_ = time;
   }
 
   bool Odometry::update(double left_pos, double right_pos, const ros::Time &time)

--- a/diff_drive_controller/test/diff_drive_open_loop.test
+++ b/diff_drive_controller/test/diff_drive_open_loop.test
@@ -1,0 +1,16 @@
+<launch>
+  <!-- Load common test stuff -->
+  <include file="$(find diff_drive_controller)/test/diff_drive_common.launch" />
+
+  <!-- Load diff drive parameter open loop -->
+  <rosparam command="load" file="$(find diff_drive_controller)/test/diffbot_open_loop.yaml" />
+
+  <!-- Controller test -->
+  <test test-name="diff_drive_test"
+        pkg="diff_drive_controller"
+        type="diff_drive_test"
+        time-limit="80.0">
+    <remap from="cmd_vel" to="diffbot_controller/cmd_vel" />
+    <remap from="odom" to="diffbot_controller/odom" />
+  </test>
+</launch>

--- a/diff_drive_controller/test/diffbot_open_loop.yaml
+++ b/diff_drive_controller/test/diffbot_open_loop.yaml
@@ -1,0 +1,2 @@
+diffbot_controller:
+  open_loop: true


### PR DESCRIPTION
The purpose of this PR is to support open loop odometry when there are no encoders.
It basically adds:
- open_loop param
- extends `Odometry` class to update using the last linear and angular velocities received by the controller, i.e. set the odometry twist directly with then and integrate the position (x, y)
