### PR TITLE
Heading normalization not needed

### DIFF
--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -4,7 +4,6 @@ project(diff_drive_controller)
 find_package(catkin REQUIRED COMPONENTS
     controller_interface
     urdf
-    angles
     tf
     nav_msgs)
 

--- a/diff_drive_controller/package.xml
+++ b/diff_drive_controller/package.xml
@@ -19,7 +19,6 @@
   <build_depend>realtime_tools</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>urdf</build_depend>
-  <build_depend>angles</build_depend>
 
   <run_depend>controller_interface</run_depend>
   <run_depend>nav_msgs</run_depend>

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -209,7 +209,7 @@ namespace diff_drive_controller{
     else
     {
       const double left_pos  = left_wheel_joint_.getPosition();
-      double right_pos = right_wheel_joint_.getPosition();
+      const double right_pos = right_wheel_joint_.getPosition();
       if (std::isnan(left_pos) || std::isnan(right_pos))
         return;
 

--- a/diff_drive_controller/src/odometry.cpp
+++ b/diff_drive_controller/src/odometry.cpp
@@ -41,7 +41,6 @@
 
 #include <diff_drive_controller/odometry.h>
 
-#include <angles/angles.h>
 #include <boost/bind.hpp>
 
 namespace diff_drive_controller
@@ -140,9 +139,6 @@ namespace diff_drive_controller
     x_       += linear * cos(direction);
     y_       += linear * sin(direction);
     heading_ += angular;
-
-    /// Normalization of angle to [-Pi, Pi]:
-    heading_ = angles::normalize_angle(heading_);
   }
 
   /**
@@ -160,8 +156,8 @@ namespace diff_drive_controller
       const double heading_old = heading_;
       const double r = linear/angular;
       heading_ += angular;
-      x_ +=  r * (sin(heading_) - sin(thetaOld));
-      y_ += -r * (cos(heading_) - cos(thetaOld));
+      x_       +=  r * (sin(heading_) - sin(heading_old));
+      y_       += -r * (cos(heading_) - cos(heading_old));
     }
   }
 

--- a/diff_drive_controller/src/odometry.cpp
+++ b/diff_drive_controller/src/odometry.cpp
@@ -134,7 +134,7 @@ namespace diff_drive_controller
 
   void Odometry::integrateRungeKutta2(double linear, double angular)
   {
-    double direction = heading_ + angular*0.5;
+    const double direction = heading_ + angular * 0.5;
 
     /// Runge-Kutta 2nd order integration:
     x_       += linear * cos(direction);
@@ -157,7 +157,7 @@ namespace diff_drive_controller
     else
     {
       /// Exact integration (should solve problems when angular is zero):
-      const double thetaOld = heading_;
+      const double heading_old = heading_;
       const double r = linear/angular;
       heading_ += angular;
       x_ +=  r * (sin(heading_) - sin(thetaOld));


### PR DESCRIPTION
This is done for the Runge-Kutta 2nd order integration, but we didn't do it for the exact integration.

Note that in any case, if we don't normalize the angle, the odometry that is finally published uses a quaternion for the heading, so it gets always normalized at that point (I've verified this on the robot).
