### PR TITLE
Preserve radius

### DIFF
--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -61,6 +61,10 @@ if (CATKIN_ENABLE_TESTING)
     test/diff_drive_wrong.test
     test/diff_drive_fail_test.cpp)
   target_link_libraries(diff_drive_fail_test ${catkin_LIBRARIES})
+  add_rostest_gtest(diff_drive_no_preserve_turning_radius_test
+    test/diff_drive_controller_no_preserve_turning_radius.test
+    test/diff_drive_no_preserve_turning_radius_test.cpp)
+  target_link_libraries(diff_drive_no_preserve_turning_radius_test ${catkin_LIBRARIES})
   add_rostest(test/diff_drive_bad_urdf.test)
   add_rostest(test/diff_drive_open_loop.test)
   add_rostest(test/skid_steer_controller.test)

--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -147,8 +147,9 @@ namespace diff_drive_controller{
     /// Number of wheel joints:
     size_t wheel_joints_size_;
 
-    // Speed limiters:
-    Commands last_cmd_;
+    /// Speed limiters:
+    Commands last1_cmd_;
+    Commands last0_cmd_;
     SpeedLimiter limiter_lin_;
     SpeedLimiter limiter_ang_;
 

--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -152,6 +152,9 @@ namespace diff_drive_controller{
     SpeedLimiter limiter_lin_;
     SpeedLimiter limiter_ang_;
 
+    /// Preserve turning radius if limiting speed:
+    bool preserve_turning_radius_;
+
   private:
     /**
      * \brief Brakes the wheels, i.e. sets the velocity to 0

--- a/diff_drive_controller/include/diff_drive_controller/speed_limiter.h
+++ b/diff_drive_controller/include/diff_drive_controller/speed_limiter.h
@@ -50,31 +50,40 @@ namespace diff_drive_controller
      * \brief Constructor
      * \param [in] has_velocity_limits     if true, applies velocity limits
      * \param [in] has_acceleration_limits if true, applies acceleration limits
+     * \param [in] has_jerk_limits         if true, applies jerk limits
      * \param [in] min_velocity Minimum velocity [m/s], usually <= 0
      * \param [in] max_velocity Maximum velocity [m/s], usually >= 0
      * \param [in] min_acceleration Minimum acceleration [m/s^2], usually <= 0
      * \param [in] max_acceleration Maximum acceleration [m/s^2], usually >= 0
+     * \param [in] min_jerk Minimum jerk [m/s^3], usually <= 0
+     * \param [in] max_jerk Maximum jerk [m/s^3], usually >= 0
      */
     SpeedLimiter(
       bool has_velocity_limits = false,
       bool has_acceleration_limits = false,
+      bool has_jerk_limits = false,
       double min_velocity = 0.0,
       double max_velocity = 0.0,
       double min_acceleration = 0.0,
-      double max_acceleration = 0.0
+      double max_acceleration = 0.0,
+      double min_jerk = 0.0,
+      double max_jerk = 0.0
     );
 
     /**
      * \brief Limit the velocity and acceleration
      * \param [in, out] v  Velocity [m/s]
-     * \param [in]      v0 Previous velocity [m/s]
+     * \param [in]      v0 Previous velocity to v  [m/s]
+     * \param [in]      v1 Previous velocity to v0 [m/s]
      * \param [in]      dt Time step [s]
+     * \return Limiting factor (1.0 if none)
      */
-    double limit(double& v, double v0, double dt);
+    double limit(double& v, double v0, double v1, double dt);
 
     /**
      * \brief Limit the velocity
      * \param [in, out] v Velocity [m/s]
+     * \return Limiting factor (1.0 if none)
      */
     double limit_velocity(double& v);
 
@@ -83,13 +92,26 @@ namespace diff_drive_controller
      * \param [in, out] v  Velocity [m/s]
      * \param [in]      v0 Previous velocity [m/s]
      * \param [in]      dt Time step [s]
+     * \return Limiting factor (1.0 if none)
      */
     double limit_acceleration(double& v, double v0, double dt);
 
+    /**
+     * \brief Limit the jerk
+     * \param [in, out] v  Velocity [m/s]
+     * \param [in]      v0 Previous velocity to v  [m/s]
+     * \param [in]      v1 Previous velocity to v0 [m/s]
+     * \param [in]      dt Time step [s]
+     * \return Limiting factor (1.0 if none)
+     * \see http://en.wikipedia.org/wiki/Jerk_%28physics%29#Motion_control
+     */
+    double limit_jerk(double& v, double v0, double v1, double dt);
+
   public:
-    // Enable/Disable velocity/acceleration limits:
+    // Enable/Disable velocity/acceleration/jerk limits:
     bool has_velocity_limits;
     bool has_acceleration_limits;
+    bool has_jerk_limits;
 
     // Velocity limits:
     double min_velocity;
@@ -98,6 +120,10 @@ namespace diff_drive_controller
     // Acceleration limits:
     double min_acceleration;
     double max_acceleration;
+
+    // Jerk limits:
+    double min_jerk;
+    double max_jerk;
   };
 
 } // namespace diff_drive_controller

--- a/diff_drive_controller/include/diff_drive_controller/speed_limiter.h
+++ b/diff_drive_controller/include/diff_drive_controller/speed_limiter.h
@@ -70,13 +70,13 @@ namespace diff_drive_controller
      * \param [in]      v0 Previous velocity [m/s]
      * \param [in]      dt Time step [s]
      */
-    void limit(double& v, double v0, double dt);
+    double limit(double& v, double v0, double dt);
 
     /**
      * \brief Limit the velocity
      * \param [in, out] v Velocity [m/s]
      */
-    void limit_velocity(double& v);
+    double limit_velocity(double& v);
 
     /**
      * \brief Limit the acceleration
@@ -84,7 +84,7 @@ namespace diff_drive_controller
      * \param [in]      v0 Previous velocity [m/s]
      * \param [in]      dt Time step [s]
      */
-    void limit_acceleration(double& v, double v0, double dt);
+    double limit_acceleration(double& v, double v0, double dt);
 
   public:
     // Enable/Disable velocity/acceleration limits:

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -191,17 +191,23 @@ namespace diff_drive_controller{
     // Velocity and acceleration limits:
     controller_nh.param("linear/x/has_velocity_limits"    , limiter_lin_.has_velocity_limits    , limiter_lin_.has_velocity_limits    );
     controller_nh.param("linear/x/has_acceleration_limits", limiter_lin_.has_acceleration_limits, limiter_lin_.has_acceleration_limits);
+    controller_nh.param("linear/x/has_jerk_limits"        , limiter_lin_.has_jerk_limits        , limiter_lin_.has_jerk_limits        );
     controller_nh.param("linear/x/max_velocity"           , limiter_lin_.max_velocity           ,  limiter_lin_.max_velocity          );
     controller_nh.param("linear/x/min_velocity"           , limiter_lin_.min_velocity           , -limiter_lin_.max_velocity          );
     controller_nh.param("linear/x/max_acceleration"       , limiter_lin_.max_acceleration       ,  limiter_lin_.max_acceleration      );
     controller_nh.param("linear/x/min_acceleration"       , limiter_lin_.min_acceleration       , -limiter_lin_.max_acceleration      );
+    controller_nh.param("linear/x/max_jerk"               , limiter_lin_.max_jerk               ,  limiter_lin_.max_jerk              );
+    controller_nh.param("linear/x/min_jerk"               , limiter_lin_.min_jerk               , -limiter_lin_.max_jerk              );
 
     controller_nh.param("angular/z/has_velocity_limits"    , limiter_ang_.has_velocity_limits    , limiter_ang_.has_velocity_limits    );
     controller_nh.param("angular/z/has_acceleration_limits", limiter_ang_.has_acceleration_limits, limiter_ang_.has_acceleration_limits);
+    controller_nh.param("angular/z/has_jerk_limits"        , limiter_ang_.has_jerk_limits        , limiter_ang_.has_jerk_limits        );
     controller_nh.param("angular/z/max_velocity"           , limiter_ang_.max_velocity           ,  limiter_ang_.max_velocity          );
     controller_nh.param("angular/z/min_velocity"           , limiter_ang_.min_velocity           , -limiter_ang_.max_velocity          );
     controller_nh.param("angular/z/max_acceleration"       , limiter_ang_.max_acceleration       ,  limiter_ang_.max_acceleration      );
     controller_nh.param("angular/z/min_acceleration"       , limiter_ang_.min_acceleration       , -limiter_ang_.max_acceleration      );
+    controller_nh.param("angular/z/max_jerk"               , limiter_ang_.max_jerk               ,  limiter_ang_.max_jerk              );
+    controller_nh.param("angular/z/min_jerk"               , limiter_ang_.min_jerk               , -limiter_ang_.max_jerk              );
 
     // Preserve turning radius if limiting velocity/acceleration/jerk:
     controller_nh.param("preserve_turning_radius", preserve_turning_radius_, preserve_turning_radius_);
@@ -231,7 +237,7 @@ namespace diff_drive_controller{
     // COMPUTE AND PUBLISH ODOMETRY
     if (open_loop_)
     {
-      odometry_.updateOpenLoop(last_cmd_.lin, last_cmd_.ang, time);
+      odometry_.updateOpenLoop(last0_cmd_.lin, last0_cmd_.ang, time);
     }
     else
     {
@@ -300,8 +306,8 @@ namespace diff_drive_controller{
 
     // Limit velocities and accelerations:
     const double cmd_dt(period.toSec());
-    const double f_lin = limiter_lin_.limit(curr_cmd.lin, last_cmd_.lin, cmd_dt);
-    const double f_ang = limiter_ang_.limit(curr_cmd.ang, last_cmd_.ang, cmd_dt);
+    const double f_lin = limiter_lin_.limit(curr_cmd.lin, last0_cmd_.lin, last1_cmd_.lin, cmd_dt);
+    const double f_ang = limiter_ang_.limit(curr_cmd.ang, last0_cmd_.ang, last1_cmd_.ang, cmd_dt);
     if (preserve_turning_radius_ && f_lin != f_ang)
     {
       const double f = std::min(f_lin, f_ang);
@@ -309,7 +315,8 @@ namespace diff_drive_controller{
       curr_cmd.lin *= f / f_lin;
       curr_cmd.ang *= f / f_ang;
     }
-    last_cmd_ = curr_cmd;
+    last1_cmd_ = last0_cmd_;
+    last0_cmd_ = curr_cmd;
 
     // Apply multipliers:
     const double ws = wheel_separation_multiplier_ * wheel_separation_;

--- a/diff_drive_controller/src/speed_limiter.cpp
+++ b/diff_drive_controller/src/speed_limiter.cpp
@@ -52,26 +52,33 @@ namespace diff_drive_controller
   SpeedLimiter::SpeedLimiter(
     bool has_velocity_limits,
     bool has_acceleration_limits,
+    bool has_jerk_limits,
     double min_velocity,
     double max_velocity,
     double min_acceleration,
-    double max_acceleration
+    double max_acceleration,
+    double min_jerk,
+    double max_jerk
   )
-  : has_velocity_limits(has_velocity_limits),
-    has_acceleration_limits(has_acceleration_limits),
-    min_velocity(min_velocity),
-    max_velocity(max_velocity),
-    min_acceleration(min_acceleration),
-    max_acceleration(max_acceleration)
+  : has_velocity_limits(has_velocity_limits)
+  , has_acceleration_limits(has_acceleration_limits)
+  , has_jerk_limits(has_jerk_limits)
+  , min_velocity(min_velocity)
+  , max_velocity(max_velocity)
+  , min_acceleration(min_acceleration)
+  , max_acceleration(max_acceleration)
+  , min_jerk(min_jerk)
+  , max_jerk(max_jerk)
   {
   }
 
-  double SpeedLimiter::limit(double& v, double v0, double dt)
+  double SpeedLimiter::limit(double& v, double v0, double v1, double dt)
   {
     const double tmp = v;
 
     limit_velocity(v);
     limit_acceleration(v, v0, dt);
+    limit_jerk(v, v0, v1, dt);
 
     return tmp != 0.0 ? v / tmp : 1.0;
   }
@@ -100,6 +107,28 @@ namespace diff_drive_controller
       const double dv = clamp(v - v0, dv_min, dv_max);
 
       v = v0 + dv;
+    }
+
+    return tmp != 0.0 ? v / tmp : 1.0;
+  }
+
+  double SpeedLimiter::limit_jerk(double& v, double v0, double v1, double dt)
+  {
+    const double tmp = v;
+
+    if (has_jerk_limits)
+    {
+      const double dv  = v  - v0;
+      const double dv0 = v0 - v1;
+
+      const double dt2 = dt * dt;
+
+      const double da_min = min_jerk * dt2;
+      const double da_max = max_jerk * dt2;
+
+      const double da = clamp(dv - dv0, da_min, da_max);
+
+      v = v0 + dv0 + da;
     }
 
     return tmp != 0.0 ? v / tmp : 1.0;

--- a/diff_drive_controller/src/speed_limiter.cpp
+++ b/diff_drive_controller/src/speed_limiter.cpp
@@ -66,33 +66,43 @@ namespace diff_drive_controller
   {
   }
 
-  void SpeedLimiter::limit(double& v, double v0, double dt)
+  double SpeedLimiter::limit(double& v, double v0, double dt)
   {
+    const double tmp = v;
+
     limit_velocity(v);
     limit_acceleration(v, v0, dt);
+
+    return tmp != 0.0 ? v / tmp : 1.0;
   }
 
-  void SpeedLimiter::limit_velocity(double& v)
+  double SpeedLimiter::limit_velocity(double& v)
   {
+    const double tmp = v;
+
     if (has_velocity_limits)
     {
       v = clamp(v, min_velocity, max_velocity);
     }
+
+    return tmp != 0.0 ? v / tmp : 1.0;
   }
 
-  void SpeedLimiter::limit_acceleration(double& v, double v0, double dt)
+  double SpeedLimiter::limit_acceleration(double& v, double v0, double dt)
   {
+    const double tmp = v;
+
     if (has_acceleration_limits)
     {
-      double dv = v - v0;
-
       const double dv_min = min_acceleration * dt;
       const double dv_max = max_acceleration * dt;
 
-      dv = clamp(dv, dv_min, dv_max);
+      const double dv = clamp(v - v0, dv_min, dv_max);
 
       v = v0 + dv;
     }
+
+    return tmp != 0.0 ? v / tmp : 1.0;
   }
 
 } // namespace diff_drive_controller

--- a/diff_drive_controller/test/diff_drive_controller_no_preserve_turning_radius.test
+++ b/diff_drive_controller/test/diff_drive_controller_no_preserve_turning_radius.test
@@ -2,14 +2,15 @@
   <!-- Load common test stuff -->
   <include file="$(find diff_drive_controller)/test/diff_drive_common.launch" />
 
-  <!-- Load diff-drive limits -->
+  <!-- Load diff-drive limits and disable preserve turning radius -->
   <rosparam command="load" file="$(find diff_drive_controller)/test/diffbot_limits.yaml" />
+  <rosparam command="load" file="$(find diff_drive_controller)/test/diffbot_no_preserve_turning_radius.yaml" />
 
   <!-- Controller test -->
   <test test-name="diff_drive_limits_test"
         pkg="diff_drive_controller"
-        type="diff_drive_limits_test"
-        time-limit="120.0">
+        type="diff_drive_no_preserve_turning_radius_test"
+        time-limit="80.0">
     <remap from="cmd_vel" to="diffbot_controller/cmd_vel" />
     <remap from="odom" to="diffbot_controller/odom" />
   </test>

--- a/diff_drive_controller/test/diff_drive_limits_test.cpp
+++ b/diff_drive_controller/test/diff_drive_limits_test.cpp
@@ -30,6 +30,37 @@
 #include "test_common.h"
 
 // TEST CASES
+TEST_F(DiffDriveControllerTest, testLinearJerkLimits)
+{
+  // wait for ROS
+  while(!isControllerAlive())
+  {
+    ros::Duration(0.1).sleep();
+  }
+  // zero everything before test
+  geometry_msgs::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  ros::Duration(2.0).sleep();
+  // get initial odom
+  nav_msgs::Odometry old_odom = getLastOdom();
+  // send a big command
+  cmd_vel.linear.x = 10.0;
+  publish(cmd_vel);
+  // wait for a while
+  ros::Duration(0.5).sleep();
+
+  nav_msgs::Odometry new_odom = getLastOdom();
+
+  // check if the robot speed is now 0.125 m.s-1, which is 1.0m.s-3 * (0.5s)^2
+  EXPECT_LT(fabs(new_odom.twist.twist.linear.x - old_odom.twist.twist.linear.x), 0.25 + VELOCITY_TOLERANCE);
+  EXPECT_LT(fabs(new_odom.twist.twist.angular.z - old_odom.twist.twist.angular.z), EPS);
+
+  cmd_vel.linear.x = 0.0;
+  publish(cmd_vel);
+}
+
 TEST_F(DiffDriveControllerTest, testLinearAccelerationLimits)
 {
   // wait for ROS
@@ -89,6 +120,37 @@ TEST_F(DiffDriveControllerTest, testLinearVelocityLimits)
   EXPECT_LT(fabs(new_odom.twist.twist.angular.z - old_odom.twist.twist.angular.z), EPS);
 
   cmd_vel.linear.x = 0.0;
+  publish(cmd_vel);
+}
+
+TEST_F(DiffDriveControllerTest, testAngularJerkLimits)
+{
+  // wait for ROS
+  while(!isControllerAlive())
+  {
+    ros::Duration(0.1).sleep();
+  }
+  // zero everything before test
+  geometry_msgs::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  ros::Duration(2.0).sleep();
+  // get initial odom
+  nav_msgs::Odometry old_odom = getLastOdom();
+  // send a big command
+  cmd_vel.angular.z = 10.0;
+  publish(cmd_vel);
+  // wait for a while
+  ros::Duration(0.5).sleep();
+
+  nav_msgs::Odometry new_odom = getLastOdom();
+
+  // check if the robot speed is now 1.0rad.s-1, which is 2.0rad.s-3 * (0.5s)^2
+  EXPECT_LT(fabs(new_odom.twist.twist.angular.z - old_odom.twist.twist.angular.z), 0.5 + VELOCITY_TOLERANCE);
+  EXPECT_LT(fabs(new_odom.twist.twist.linear.x - old_odom.twist.twist.linear.x), EPS);
+
+  cmd_vel.angular.z = 0.0;
   publish(cmd_vel);
 }
 

--- a/diff_drive_controller/test/diff_drive_no_preserve_turning_radius_test.cpp
+++ b/diff_drive_controller/test/diff_drive_no_preserve_turning_radius_test.cpp
@@ -1,0 +1,78 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2013, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics, Inc. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+/// \author Paul Mathieu
+
+#include "test_common.h"
+
+// TEST CASES
+TEST_F(DiffDriveControllerTest, testNoPreserveTurningRadius)
+{
+  // wait for ROS
+  while(!isControllerAlive())
+  {
+    ros::Duration(0.1).sleep();
+  }
+  // zero everything before test
+  geometry_msgs::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  ros::Duration(2.0).sleep();
+  // send a big command
+  cmd_vel.linear.x = 10.0;
+  cmd_vel.angular.z = 1.0;
+  publish(cmd_vel);
+  // wait for a while
+  ros::Duration(0.5).sleep();
+
+  nav_msgs::Odometry odom = getLastOdom();
+
+  // check if the turning radius is not preserved
+  const double r_cmd_vel = cmd_vel.linear.x / cmd_vel.angular.z;
+  const double r_odom    = odom.twist.twist.linear.x / odom.twist.twist.angular.z;
+
+  EXPECT_GT(fabs(r_cmd_vel - r_odom), 1.0);
+
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "diff_drive_no_preserve_turning_radius_test");
+
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+  //ros::Duration(0.5).sleep();
+  int ret = RUN_ALL_TESTS();
+  spinner.stop();
+  ros::shutdown();
+  return ret;
+}

--- a/diff_drive_controller/test/diff_drive_test.cpp
+++ b/diff_drive_controller/test/diff_drive_test.cpp
@@ -123,6 +123,39 @@ TEST_F(DiffDriveControllerTest, testTurn)
   EXPECT_NEAR(fabs(new_odom.twist.twist.angular.z), M_PI/10.0, EPS);
 }
 
+TEST_F(DiffDriveControllerTest, testPreserveTurningRadius)
+{
+  // wait for ROS
+  while(!isControllerAlive())
+  {
+    ros::Duration(0.1).sleep();
+  }
+  // zero everything before test
+  geometry_msgs::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  ros::Duration(2.0).sleep();
+  // send a big command
+  cmd_vel.linear.x = 10.0;
+  cmd_vel.angular.z = 1.0;
+  publish(cmd_vel);
+  // wait for a while
+  ros::Duration(0.5).sleep();
+
+  nav_msgs::Odometry odom = getLastOdom();
+
+  // check if the turning radius is not preserved
+  const double r_cmd_vel = cmd_vel.linear.x / cmd_vel.angular.z;
+  const double r_odom    = odom.twist.twist.linear.x / odom.twist.twist.angular.z;
+
+  EXPECT_LT(fabs(r_cmd_vel - r_odom), EPS);
+
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/diff_drive_controller/test/diffbot_limits.yaml
+++ b/diff_drive_controller/test/diffbot_limits.yaml
@@ -7,9 +7,14 @@ diffbot_controller:
       has_acceleration_limits: true
       min_acceleration: -0.5
       max_acceleration: 1.0
+      has_jerk_limits: true
+      min_jerk: -0.5
+      max_jerk: 1.0
   angular:
     z:
       has_velocity_limits: true
       max_velocity: 2.0
       has_acceleration_limits: true
       max_acceleration: 2.0
+      has_jerk_limits: true
+      max_jerk: 2.0

--- a/diff_drive_controller/test/diffbot_no_preserve_turning_radius.yaml
+++ b/diff_drive_controller/test/diffbot_no_preserve_turning_radius.yaml
@@ -1,0 +1,2 @@
+diffbot_controller:
+  preserve_turning_radius: false


### PR DESCRIPTION
Preserves radius when limiting the linear/angular speed/acceleration/jerk.
Also adds jerk limits.
